### PR TITLE
fix dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>1.7</source>
-						<target>1.7</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
`mvn install` requires Java 8 because of lambda expressions used throughout the code. 